### PR TITLE
refactor: unify MQTT client usage between MCP and WebRTC

### DIFF
--- a/web/src/components/ChatInterface.tsx
+++ b/web/src/components/ChatInterface.tsx
@@ -1,6 +1,6 @@
 import { Mic, Volume2, Camera } from 'lucide-react'
 import { EmotionAnimation } from './EmotionAnimation'
-import { EmotionSelector } from './EmotionSelector'
+// import { EmotionSelector } from './EmotionSelector'
 import { ChatMessages } from './ChatMessages'
 import { MqttSettings } from './MqttSettings'
 import { useAudioPlaying } from '@/hooks/useAudioPlaying'
@@ -47,7 +47,7 @@ export function ChatInterface({
   showVideo,
   setShowVideo,
   selectedEmotion,
-  setSelectedEmotion,
+  // setSelectedEmotion,
   videoRef,
   audioRef,
   volume,
@@ -100,10 +100,10 @@ export function ChatInterface({
           onConfigChange={onMqttConfigChange}
           isConnected={isMqttConnected}
         />
-        <EmotionSelector 
+        {/*<EmotionSelector 
           selectedEmotion={selectedEmotion}
           onEmotionSelect={setSelectedEmotion}
-        />
+        />*/}
       </div>
 
       <div 

--- a/web/src/hooks/useWebRTCMqtt.ts
+++ b/web/src/hooks/useWebRTCMqtt.ts
@@ -1,27 +1,15 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
-import mqtt, { type MqttClient as BaseMqttClient } from 'mqtt'
+import { useState, useRef, useCallback } from 'react'
+import { type MqttClient as BaseMqttClient } from 'mqtt'
 import { MqttWebRTCSignaling } from '@/services/mqtt-webrtc-signaling'
-import { webrtcClientConfig } from '@/config/mqtt'
 import type { ConnectionState, UseWebRTCOptions, UseWebRTCReturn } from '@/types/webrtc'
-import { webrtcLogger, mqttLogger } from '@/utils/logger'
+import { webrtcLogger } from '@/utils/logger'
 
 export interface UseWebRTCMqttOptions extends Omit<UseWebRTCOptions, 'signalingId'> {
-  brokerUrl?: string
-  username?: string
-  password?: string
-  clientId?: string
-  connectTimeout?: number
-  reconnectPeriod?: number
-  autoConnect?: boolean
+  mqttClient?: BaseMqttClient | null  // Accept external MQTT client
 }
 
 export function useWebRTCMqtt({
-  brokerUrl,
-  username,
-  password,
-  clientId,
-  connectTimeout,
-  reconnectPeriod,
+  mqttClient: externalMqttClient,
   config = {},
   mediaConstraints = {
     video: true,
@@ -34,93 +22,51 @@ export function useWebRTCMqtt({
       channelCount: 2
     }
   },
-  autoConnect = true,
   onASRResponse,
   onTTSText
-}: UseWebRTCMqttOptions): UseWebRTCReturn & { mqttConnected: boolean } {
+}: UseWebRTCMqttOptions): UseWebRTCReturn {
   const [localStream, setLocalStream] = useState<MediaStream | null>(null)
   const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null)
   const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected')
-  const [mqttConnected, setMqttConnected] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const [isAudioEnabled, setIsAudioEnabled] = useState(true)
   const [isVideoEnabled, setIsVideoEnabled] = useState(true)
   
-  const mqttClientRef = useRef<BaseMqttClient | null>(null)
+  const mqttClientRef = useRef<BaseMqttClient | null | undefined>(externalMqttClient)
   const signalingRef = useRef<MqttWebRTCSignaling | null>(null)
-  const hasConnectedRef = useRef(false)
 
-  const actualClientId = useRef(clientId || `webrtc_client_${Math.random().toString(36).substring(2, 10)}`).current
-
-  const connectMqtt = useCallback(async (): Promise<void> => {
-    const mqttConfig = {
-      ...webrtcClientConfig,
-      brokerUrl: brokerUrl || webrtcClientConfig.brokerUrl,
-      username: username || webrtcClientConfig.username,
-      password: password || webrtcClientConfig.password,
-      connectTimeout: connectTimeout || webrtcClientConfig.connectTimeout,
-      reconnectPeriod: reconnectPeriod || webrtcClientConfig.reconnectPeriod,
-      clientId: actualClientId,
-      clean: true
-    }
-    
-    return new Promise((resolve, reject) => {
-      mqttLogger.info(`📡 WebRTC: Connecting to MQTT broker at ${mqttConfig.brokerUrl} (ClientID: ${actualClientId})`)
-      
-      const client = mqtt.connect(mqttConfig.brokerUrl, {
-        clientId: mqttConfig.clientId,
-        username: mqttConfig.username,
-        password: mqttConfig.password,
-        clean: mqttConfig.clean,
-        connectTimeout: mqttConfig.connectTimeout,
-        reconnectPeriod: mqttConfig.reconnectPeriod,
-        protocolVersion: mqttConfig.protocolVersion
-      })
-
-      client.on('connect', () => {
-        mqttLogger.info(`✅ WebRTC: MQTT connected (ClientID: ${actualClientId})`)
-        setMqttConnected(true)
-        mqttClientRef.current = client
-        resolve()
-      })
-
-      client.on('error', (err) => {
-        mqttLogger.error('❌ WebRTC: MQTT connection error:', err.message)
-        setError(err)
-        reject(err)
-      })
-
-      client.on('disconnect', () => {
-        mqttLogger.warn('🔌 WebRTC: MQTT disconnected')
-        setMqttConnected(false)
-      })
-
-      client.on('reconnect', () => {
-        mqttLogger.info('🔄 WebRTC: MQTT reconnecting...')
-      })
-    })
-  }, [brokerUrl, actualClientId, username, password, connectTimeout, reconnectPeriod])
+  // Update MQTT client ref when external client changes
+  mqttClientRef.current = externalMqttClient || null
 
   const connect = useCallback(async () => {
     try {
       setError(null)
       
-      // Connect MQTT if not connected
-      if (!mqttClientRef.current || !mqttConnected) {
-        webrtcLogger.info('🔗 WebRTC: Step 1/2 - Establishing MQTT connection')
-        await connectMqtt()
+      // Check if MQTT client is provided and connected
+      if (!mqttClientRef.current) {
+        throw new Error('MQTT client not provided. WebRTC requires the MCP MQTT client to be connected first.')
       }
 
-      webrtcLogger.info('🎥 WebRTC: Step 2/2 - Starting WebRTC signaling')
+      if (!mqttClientRef.current.connected) {
+        throw new Error('MQTT client is not connected. Please ensure MCP is connected first.')
+      }
+
+      webrtcLogger.info('🎥 WebRTC: Starting WebRTC signaling with shared MQTT client')
       setConnectionState('connecting')
       
       if (signalingRef.current) {
         signalingRef.current.disconnect()
       }
 
+      // Get client ID from the MQTT client's clientId property
+      const clientId = (mqttClientRef.current as any).options?.clientId
+      if (!clientId) {
+        throw new Error('Cannot get client ID from MQTT client')
+      }
+      
       signalingRef.current = new MqttWebRTCSignaling({
         mqttClient: mqttClientRef.current,
-        clientId: actualClientId,
+        clientId,
         config,
         mediaConstraints,
         callbacks: {
@@ -134,14 +80,13 @@ export function useWebRTCMqtt({
       })
 
       await signalingRef.current.connect()
-      webrtcLogger.info('✅ WebRTC: Connection established')
+      webrtcLogger.info('✅ WebRTC: Connection established with shared MQTT client')
     } catch (err) {
       webrtcLogger.error('❌ WebRTC: Failed to connect:', err)
       setError(err as Error)
       setConnectionState('failed')
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [actualClientId, config, mediaConstraints, onASRResponse, mqttConnected, connectMqtt])
+  }, [config, mediaConstraints, onASRResponse, onTTSText])
 
   const disconnect = useCallback(() => {
     webrtcLogger.info('🔌 WebRTC: Manual disconnect initiated')
@@ -169,20 +114,12 @@ export function useWebRTCMqtt({
         remoteStream.getTracks().forEach(track => track.stop())
       }
       
-      // Disconnect MQTT client
-      if (mqttClientRef.current && mqttClientRef.current.connected) {
-        webrtcLogger.info('🔌 Disconnecting MQTT client...')
-        mqttClientRef.current.end(true) // Force close
-        mqttClientRef.current = null
-      }
-      
-      // Reset all state
-      setMqttConnected(false)
+      // Don't disconnect the MQTT client since it's shared with MCP
+      // Just reset WebRTC state
       setConnectionState('disconnected')
       setLocalStream(null)
       setRemoteStream(null)
       setError(null)
-      hasConnectedRef.current = false
       
       webrtcLogger.info('✅ WebRTC: Disconnect completed')
     } catch (error) {
@@ -233,44 +170,28 @@ export function useWebRTCMqtt({
     }
   }, [isVideoEnabled, connectionState, connect, disconnect])
 
-  useEffect(() => {
-    if (autoConnect && !hasConnectedRef.current) {
-      hasConnectedRef.current = true
-      webrtcLogger.info('🎯 WebRTC: Auto-connecting')
-      connect()
+  // Cleanup on unmount
+  const cleanup = useCallback(() => {
+    webrtcLogger.info('🧹 Cleaning up WebRTC connections...')
+    
+    if (signalingRef.current) {
+      webrtcLogger.info('🔌 Disconnecting WebRTC signaling')
+      signalingRef.current.disconnect()
+      signalingRef.current = null
     }
-
-    return () => {
-      webrtcLogger.info('🧹 Cleaning up WebRTC connections...')
-      
-      if (signalingRef.current) {
-        webrtcLogger.info('🔌 Disconnecting WebRTC signaling')
-        signalingRef.current.disconnect()
-        signalingRef.current = null
-      }
-      
-      if (mqttClientRef.current) {
-        webrtcLogger.info('🔌 Disconnecting MQTT client')
-        mqttClientRef.current.end()
-        mqttClientRef.current = null
-      }
-      
-      setMqttConnected(false)
-      setConnectionState('disconnected')
-      setLocalStream(null)
-      setRemoteStream(null)
-      hasConnectedRef.current = false
-      
-      webrtcLogger.info('✅ WebRTC cleanup completed')
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoConnect])
+    
+    // Don't disconnect MQTT client since it's shared
+    setConnectionState('disconnected')
+    setLocalStream(null)
+    setRemoteStream(null)
+    
+    webrtcLogger.info('✅ WebRTC cleanup completed')
+  }, [])
 
   return {
     localStream,
     remoteStream,
     connectionState,
-    mqttConnected,
     isConnecting: connectionState === 'connecting',
     isConnected: connectionState === 'connected',
     error,
@@ -279,6 +200,7 @@ export function useWebRTCMqtt({
     toggleAudio,
     toggleVideo,
     isAudioEnabled,
-    isVideoEnabled
+    isVideoEnabled,
+    cleanup
   }
 }

--- a/web/src/lib/mcp-mqtt-server.ts
+++ b/web/src/lib/mcp-mqtt-server.ts
@@ -92,6 +92,7 @@ export class McpMqttServer {
         this.mqttClient.on('connect', () => {
           this.connectionState = 'connected'
           mqttLogger.info(`✅ Step 1/3: Connected to broker ${this.connectionOptions.brokerUrl} (${this.connectionOptions.clientId})`)
+          mqttLogger.info(`🔵 MCP Server Client ID: ${this.connectionOptions.clientId}`)
           
           // Use setTimeout to avoid race condition with subscriptions
           setTimeout(() => {

--- a/web/src/services/mqtt-webrtc-signaling.ts
+++ b/web/src/services/mqtt-webrtc-signaling.ts
@@ -34,9 +34,11 @@ export class MqttWebRTCSignaling {
   private messageTopic: string
   private messageHandler: ((topic: string, message: Buffer) => void) | null = null
   private ttsText: string = ''
+  private isExternalClient: boolean = false
 
   constructor(options: MqttWebRTCSignalingOptions) {
     this.mqttClient = options.mqttClient
+    this.isExternalClient = !!options.mqttClient // Mark if client was provided externally
     this.clientId = options.clientId || `webrtc_client_${Math.random().toString(36).substring(7)}`
     this.config = { ...defaultWebRTCConfig, ...options.config }
     this.mediaConstraints = { ...defaultMediaConstraints, ...options.mediaConstraints }
@@ -60,6 +62,7 @@ export class MqttWebRTCSignaling {
     }
 
     try {
+      webrtcLogger.info(`🟢 WebRTC using Client ID: ${this.clientId}`)
       webrtcLogger.info('Step 1: Starting WebRTC signaling...')
       this.updateConnectionState('connecting')
       
@@ -337,6 +340,11 @@ export class MqttWebRTCSignaling {
         })
         
         this.messageHandler = null
+      }
+
+      // Don't disconnect the MQTT client if it was provided externally
+      if (!this.isExternalClient) {
+        this.mqttClient = null
       }
 
       // Reset state

--- a/web/src/types/webrtc.ts
+++ b/web/src/types/webrtc.ts
@@ -85,4 +85,5 @@ export interface UseWebRTCReturn {
   toggleVideo: (enabled?: boolean) => Promise<void>
   isAudioEnabled: boolean
   isVideoEnabled: boolean
+  cleanup?: () => void  // Optional cleanup function
 }


### PR DESCRIPTION
- WebRTC now reuses MCP's MQTT client instance instead of creating its own
- Both MCP and WebRTC share the same client ID for consistent backend tracking
- Removed redundant MQTT connection logic from WebRTC hooks
- Added cleanup handling for shared MQTT client