### PR TITLE
fix: resolve MCP tools discovery issue with wait mechanism

### DIFF
--- a/app/conversation_agent.py
+++ b/app/conversation_agent.py
@@ -157,10 +157,25 @@ class ConversationAgent:
             logger.info(f"MCP connected with device_id: {device_to_use}")
             self.device_id = device_to_use
 
-            # Update MCP tools
-            if self.mcp_client.mcp_tools:
-                self.mcp_tools = self.mcp_client.mcp_tools
-                self._initialize_agent()
+            # Wait for tools to be loaded with timeout
+            max_wait_time = 10  # seconds
+            wait_interval = 0.5  # seconds
+            waited_time = 0
+            
+            while waited_time < max_wait_time:
+                if self.mcp_client.mcp_tools:
+                    logger.info(f"MCP tools loaded: {len(self.mcp_client.mcp_tools)} tools found")
+                    self.mcp_tools = self.mcp_client.mcp_tools
+                    self._initialize_agent()
+                    break
+                    
+                await anyio.sleep(wait_interval)
+                waited_time += wait_interval
+                logger.debug(f"Waiting for MCP tools... ({waited_time:.1f}s)")
+            
+            if not self.mcp_client.mcp_tools:
+                logger.warning(f"No MCP tools loaded after {max_wait_time}s timeout")
+                
         else:
             logger.error("Failed to connect MCP")
 


### PR DESCRIPTION
Add timeout-based waiting mechanism to ensure MCP tools are fully loaded before initializing the agent. This fixes the race condition where agent was created before MCP tools were available.

- Wait up to 10 seconds for MCP tools to load after connection
- Add debug logging to track tool loading progress
- Gracefully handle timeout with warning message
- Ensures agent includes all available MCP tools at runtime