### PR TITLE
fix(web): remove duplicate conversation logging in TTS handler

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -125,7 +125,7 @@ function App() {
       setAiReplyText('')
     },
     onTTSText: (text: string) => {
-      conversationLogger.assistant(text)
+      // conversationLogger.assistant(text)
       setAiReplyText(text)
       setLlmLoading(null)
     },


### PR DESCRIPTION
The conversationLogger.assistant() call in the TTS handler was causing duplicate log entries since the conversation is already being logged in the ASR handler. This comment prevents the duplicate logging while preserving the code structure for potential future use.