### PR TITLE
refactor: separate volc-server credentials from runtime config

### DIFF
--- a/volc-server/.env.example
+++ b/volc-server/.env.example
@@ -2,78 +2,18 @@
 VOLC_ACCESS_KEY_ID=
 VOLC_SECRET_KEY=
 
-# RTC configuration (required)
+# RTC credentials (required)
 VOLC_RTC_APP_ID=
 VOLC_RTC_APP_KEY=
 
-# ASR/TTS configuration
+# Speech service credentials
 VOLC_ASR_APP_ID=
 VOLC_TTS_APP_ID=
-VOLC_ASR_CLUSTER=volcengine_streaming_common
-VOLC_TTS_CLUSTER=volcano_tts
-
-# Voice configuration
-VOLC_TTS_PROVIDER=volcano
-VOLC_TTS_MODE=standard
-VOLC_TTS_VOICE_TYPE=BV005_streaming
-VOLC_TTS_SPEED_RATIO=0.95
-VOLC_TTS_PITCH_RATIO=1
-VOLC_TTS_VOLUME_RATIO=1
-VOLC_TTS_SPEECH_RATIO=1
-VOLC_TTS_PITCH_RATE=0
-VOLC_TTS_SPEECH_RATE=0
 VOLC_TTS_APP_TOKEN=
 VOLC_TTS_RESOURCE_ID=
-VOLC_TTS_IGNORE_BRACKET_TEXT=[1,2]
-VOLC_TTS_EMOTION=
-VOLC_TTS_EMOTION_INTENSITY=0.8
-VOLC_TTS_DISABLE_MARKDOWN_FILTER=false
-VOLC_TTS_ENABLE_LATEX_TN=false
 
-# LLM configuration
-VOLC_LLM_MODE=ArkV3             # Set to CustomLLM to use a third-party agent
-VOLC_LLM_ENDPOINT_ID=           # Required for ArkV3 mode
-VOLC_LLM_URL=                   # Required when VOLC_LLM_MODE=CustomLLM
-VOLC_LLM_API_KEY=               # Optional Bearer token forwarded as Authorization header
-VOLC_LLM_MODEL_NAME=qwen-flash
-VOLC_LLM_TEMPERATURE=0.7
-VOLC_LLM_TOP_P=0.9
-VOLC_LLM_MAX_TOKENS=512
-VOLC_LLM_HISTORY_LENGTH=5
-VOLC_LLM_ENABLE_ROUND_ID=true
-VOLC_LLM_EXTRA_HEADERS={"X-Request-Source":"RTC-VoiceChat"}   # Optional JSON string
-VOLC_LLM_STREAM_OPTIONS={"include_usage":true}                  # Optional JSON string
-VOLC_LLM_USER_PROMPTS=[{"Role":"user","Content":"你好"}]      # Optional JSON array
-VOLC_LLM_SYSTEM_MESSAGE=                                         # Optional system prompt; leave blank for CustomLLM
-VOLC_LLM_VISION_ENABLE=false
+# Custom LLM forwarding
+VOLC_LLM_URL=
+VOLC_LLM_API_KEY=
 
-# Agent configuration
-VOLC_AGENT_USER_ID=emq-ai-bot
-VOLC_AGENT_WELCOME_MESSAGE=嗨～我是 EMQ，很高兴见到你！想聊点什么呢？
-VOLC_AGENT_ENABLE_CONVERSATION_CALLBACK=true
-VOLC_AGENT_ANS_MODE=2
-VOLC_AGENT_VOICEPRINT_MODE=1
-
-# Task configuration
-VOLC_TASK_ID=emq-aigc-task-001
-
-# Scene configuration
-VOLC_SCENE_ICON=https://lf3-rtc-demo.volccdn.com/obj/rtc-aigc-assets/DoubaoAvatar.png
-VOLC_SCENE_NAME=EMQ 陪伴助手
-VOLC_SCENE_DEFAULT=emq-mcp-ai-companion
-
-# Avatar configuration
-VOLC_AVATAR_ENABLED=false
-VOLC_AVATAR_TYPE=3min
-VOLC_AVATAR_ROLE=250623-zhibo-linyunzhi
-VOLC_AVATAR_BACKGROUND_URL=
-VOLC_AVATAR_VIDEO_BITRATE=2000
-
-# API configuration
-VOLC_API_REGION=cn-north-1
-VOLC_API_VERSION=2024-12-01
-VOLC_INTERRUPT_MODE=0
-VOLC_INTERRUPT_SPEECH_DURATION=600
-VOLC_INTERRUPT_SILENCE_TIME=1000
-VOLC_INTERRUPT_VOLUME_GAIN=0.6
-VOLC_INTERRUPT_KEYWORDS=["谢谢","谢谢你","我知道了","好的我知道了","好的","停","暂停","可以了","别说了","Stop","Thank you","Got it","I'm good","Okay","Enough","Pause"]
+# 👉 All non-sensitive tuning parameters now live in src/config.ts

--- a/volc-server/README.md
+++ b/volc-server/README.md
@@ -3,7 +3,7 @@
 Bun + TypeScript server that proxies VolcEngine AIGC real-time voice APIs.
 
 - Exposes `/getScenes` and `/proxy` endpoints matching the Web client contract
-- Loads configuration entirely from environment variables, no JSON config files needed
+- Keeps secrets in `.env` while the rest of the scene/voice tuning lives in `src/config.ts`
 - Autogenerates Room/User IDs and 24h RTC tokens
 - Signs VolcEngine TOP gateway requests and forwards `StartVoiceChat` / `StopVoiceChat`
 
@@ -12,15 +12,15 @@ Bun + TypeScript server that proxies VolcEngine AIGC real-time voice APIs.
 ```bash
 cd volc-server
 cp .env.example .env
-# Fill in all required configuration values:
-# VOLC_ACCESS_KEY_ID / VOLC_SECRET_KEY (required)
-# VOLC_RTC_APP_ID / VOLC_RTC_APP_KEY (required)
-# VOLC_ASR_APP_ID / VOLC_TTS_APP_ID (for speech services)
-# VOLC_LLM_ENDPOINT_ID (for LLM services)
-# Other optional configurations for voice, LLM, agent, and avatar settings
+# Fill in the credential-only .env:
+#   VOLC_ACCESS_KEY_ID / VOLC_SECRET_KEY
+#   VOLC_RTC_APP_ID / VOLC_RTC_APP_KEY
+#   VOLC_ASR_APP_ID / VOLC_TTS_APP_ID / VOLC_TTS_APP_TOKEN
+#   VOLC_LLM_URL / VOLC_LLM_API_KEY (when using CustomLLM)
+# Then edit src/config.ts for non-sensitive scene/voice/LLM parameters
 ```
 
-The server now loads all configuration from environment variables only. No JSON config files are needed, making it more secure and easier to manage across different environments.
+Secrets stay out of version control in `.env`, while `src/config.ts` carries shareable defaults you can commit alongside the proxy. The loader now validates only the environment secrets, so you can add or tweak config fields without touching `env.ts`.
 
 ## 2. Install Dependencies
 
@@ -61,15 +61,16 @@ curl -X POST 'http://localhost:3001/proxy?Action=StartVoiceChat' \
 volc-server/
 ├── src/
 │   ├── server.ts          # Bun HTTP server entry
-│   ├── env.ts             # Runtime environment validation with type conversion
+│   ├── config.ts          # Shared, non-sensitive runtime defaults
+│   ├── env.ts             # Runtime environment validation + credential merge
 │   ├── types.ts           # Scene / API typings
 │   ├── handlers.ts        # HTTP request handlers
 │   ├── lib/
 │   │   └── token.ts       # RTC token generator
 │   └── scenes/
 │       └── loader.ts      # Scene builder from environment variables
-├── .env.example           # Complete environment variable template
-├── .env                   # Your actual configuration (not in version control)
+├── .env.example           # Credential-only template
+├── .env                   # Actual secrets (gitignored)
 ├── package.json
 ├── bunfig.toml
 └── tsconfig.json
@@ -77,55 +78,85 @@ volc-server/
 
 ## 6. Configuration
 
-The server uses environment variables exclusively for configuration. Key categories:
+Runtime settings are now split between two files:
 
-- **Credentials**: `VOLC_ACCESS_KEY_ID`, `VOLC_SECRET_KEY`
-- **RTC**: `VOLC_RTC_APP_ID`, `VOLC_RTC_APP_KEY`
-- **Speech**: `VOLC_ASR_APP_ID`, `VOLC_TTS_APP_ID`, `VOLC_TTS_PROVIDER`, `VOLC_TTS_MODE`, `VOLC_TTS_VOICE_TYPE`
-- **Interrupts**: `VOLC_INTERRUPT_MODE`, `VOLC_INTERRUPT_SPEECH_DURATION`, `VOLC_INTERRUPT_SILENCE_TIME`, `VOLC_INTERRUPT_VOLUME_GAIN`, `VOLC_INTERRUPT_KEYWORDS`
-- **LLM**: `VOLC_LLM_ENDPOINT_ID`, `VOLC_LLM_SYSTEM_MESSAGE`
-- **Agent**: `VOLC_AGENT_USER_ID`, `VOLC_AGENT_WELCOME_MESSAGE`, `VOLC_AGENT_ANS_MODE` (default 2 = medium), `VOLC_AGENT_VOICEPRINT_MODE` (default 1 = realtime)
-- **Scene**: `VOLC_SCENE_NAME`, `VOLC_SCENE_ICON`
-- **Avatar**: `VOLC_AVATAR_ENABLED`, `VOLC_AVATAR_TYPE`
+- `.env`: **secrets only** (`VOLC_ACCESS_KEY_ID`, `VOLC_SECRET_KEY`, `VOLC_RTC_APP_ID`, `VOLC_RTC_APP_KEY`, `VOLC_ASR_APP_ID`, `VOLC_TTS_APP_ID`, `VOLC_TTS_APP_TOKEN`, `VOLC_TTS_RESOURCE_ID`, `VOLC_LLM_URL`, `VOLC_LLM_API_KEY`).
+- `src/config.ts`: **non-sensitive scene/voice/LLM parameters** expressed with the same field names used by Volc StartVoiceChat payloads (e.g. `ASRConfig.Provider`, `ASRConfig.VADConfig.SilenceTime`, `TTSConfig.Mode`, `LLMConfig.ModelName`, etc.), plus local metadata such as agent persona and scene details.
 
-See `.env.example` for all available options and their defaults.
+See `.env.example` plus the inline comments inside `src/config.ts` for the latest defaults. Because `src/config.ts` exports the same `VOLC_*` keys, the rest of this document still refers to each option by its familiar name.
 
-`VOLC_INTERRUPT_KEYWORDS` accepts either a comma-separated list or a JSON array string. The defaults cover common Chinese and English interrupt keywords, e.g. "谢谢", "停", "Stop".
+`VOLC_INTERRUPT_KEYWORDS` is now edited as a literal array inside `src/config.ts`. The stock list already covers common Chinese and English interrupt phrases such as "谢谢", "停", and "Stop".
+
+### ASRConfig quick reference
+
+`config.ts` follows the official ASR schema (see “语音识别配置” in the Volc docs). When you tweak ASR behavior, update the `asrConfig` block directly:
+
+```ts
+export const runtimeConfig = {
+  // ...
+  asrConfig: {
+    Provider: 'volcano',
+    ProviderParams: {
+      Mode: 'smallmodel',
+      Cluster: 'volcengine_streaming_common',
+      // AccessToken / ApiResourceId stay in .env if needed
+    },
+    VADConfig: {
+      SilenceTime: 600,
+      // PrefixTime / SuffixTime / AIVAD available if you need fine‑grained control
+    },
+    VolumeGain: 0.5,
+    TurnDetectionMode: 0,
+  },
+}
+```
+
+This maps 1‑to‑1 to the `StartVoiceChat.ASRConfig` payload, making it easy to copy snippets from the Volc documentation.
 
 ### CustomLLM integration
 
-Set `VOLC_LLM_MODE=CustomLLM` when you want VolcEngine to call a third-party agent instead of an Ark endpoint. The proxy fills the `StartVoiceChat` payload directly from environment variables:
+Set `llmConfig.Mode` to `CustomLLM` inside `src/config.ts` when you want VolcEngine to call a third-party agent instead of an Ark endpoint. Keep the actual endpoint and token in `.env`.
 
 - `VOLC_LLM_URL` (required): HTTPS endpoint of your agent (must support SSE and return `data: [DONE]`).
 - `VOLC_LLM_API_KEY` (optional): forwarded as `Authorization: Bearer <token>`.
-- `VOLC_LLM_MODEL_NAME`: copied to the `model` field of each request.
-- `VOLC_LLM_TEMPERATURE`, `VOLC_LLM_TOP_P`, `VOLC_LLM_MAX_TOKENS`: numeric sampling parameters.
-- `VOLC_LLM_HISTORY_LENGTH`: controls how many turns VolcEngine sends in `messages`.
-- `VOLC_LLM_EXTRA_HEADERS`, `VOLC_LLM_STREAM_OPTIONS`, `VOLC_LLM_USER_PROMPTS`: JSON strings for advanced options documented by VolcEngine.
+- `LLMConfig.ModelName`, `LLMConfig.Temperature`, `LLMConfig.TopP`, `LLMConfig.MaxTokens`, `LLMConfig.HistoryLength`, `LLMConfig.ExtraHeaders`, `LLMConfig.StreamOptions`, `LLMConfig.UserPrompts`: edit these fields in `src/config.ts` to control how the payload is built.
 
-Example snippet for a locally hosted agent:
+Config snippet for a locally hosted agent:
+
+```ts
+export const runtimeConfig = {
+  // ...
+  llmConfig: {
+    Mode: 'CustomLLM',
+    ModelName: 'qwen-flash',
+    Temperature: 0.7,
+    TopP: 0.9,
+    MaxTokens: 512,
+    HistoryLength: 5,
+    EnableRoundId: true,
+    StreamOptions: { include_usage: true },
+  },
+  // ...
+}
+```
+
+`.env` still carries the endpoint and key:
 
 ```env
-VOLC_LLM_MODE=CustomLLM
 VOLC_LLM_URL=https://demo.emqx.com:8081/chat-stream
 VOLC_LLM_API_KEY=4ecf5336172f1a715196f8bbd35df00d
-VOLC_LLM_MODEL_NAME=qwen-flash
-VOLC_LLM_TEMPERATURE=0.7
-VOLC_LLM_TOP_P=0.9
-VOLC_LLM_MAX_TOKENS=512
-VOLC_LLM_HISTORY_LENGTH=5
-VOLC_LLM_ENABLE_ROUND_ID=true
-VOLC_LLM_STREAM_OPTIONS={"include_usage":true}
 ```
 
 ### Selecting a natural TTS profile
 
-- `VOLC_TTS_MODE`:
+Head to `ttsConfig` inside `src/config.ts` to pick the voice profile that best matches your scene:
+
+- `TTSConfig.Mode`:
   - `standard` (default) uses the traditional Volc streaming TTS, which maps to `speed_ratio/pitch_ratio/volume_ratio`.
   - `bigtts` uses a large TTS synthesis model (more natural and expressive), automatically mapped to `speech_ratio/pitch_rate`.
-  - `bidirection` connects to a streaming large model and requires `VOLC_TTS_APP_TOKEN` and `VOLC_TTS_RESOURCE_ID`. Additional features can be toggled via `VOLC_TTS_DISABLE_MARKDOWN_FILTER` and `VOLC_TTS_ENABLE_LATEX_TN`.
-- `VOLC_TTS_IGNORE_BRACKET_TEXT` accepts a JSON array or a comma-separated list; e.g., `[1,2]` filters text inside brackets.
-- Optional emotion parameters: set `VOLC_TTS_EMOTION` and `VOLC_TTS_EMOTION_INTENSITY` (range 0–1) to add emotional coloring to the large-model voice.
+  - `bidirection` connects to a streaming large model and still requires `VOLC_TTS_APP_TOKEN` and `VOLC_TTS_RESOURCE_ID` in `.env`. Additional features can be toggled via `TTSConfig.DisableMarkdownFilter` and `TTSConfig.EnableLatexTn`.
+- `TTSConfig.IgnoreBracketText` remains an array; set `[1,2]` to filter bracketed text.
+- Optional emotion parameters: set `TTSConfig.Emotion` and `TTSConfig.EmotionIntensity` (range 0–1) to add emotional coloring to the large-model voice.
 
 VolcEngine docs for reference:
 

--- a/volc-server/src/config.ts
+++ b/volc-server/src/config.ts
@@ -1,0 +1,203 @@
+/**
+ * Shared runtime configuration that is safe to commit.
+ * Fields follow the structure of the Volc StartVoiceChat payload
+ * (ASRConfig / TTSConfig / LLMConfig, etc.) for easier copy-and-paste.
+ */
+
+export interface SceneSettings {
+  taskId: string
+  icon: string
+  name: string
+  defaultSceneId: string
+}
+
+export interface AgentSettings {
+  userId: string
+  welcomeMessage: string
+  enableConversationStateCallback: boolean
+  ansMode: number
+  voiceprintMode: number
+}
+
+export interface InterruptSettings {
+  mode: number
+  speechDuration: number
+  silenceTime: number
+  volumeGain: number
+  keywords: string[]
+}
+
+export interface AsrConfig {
+  Provider: string
+  ProviderParams: {
+    Mode: 'smallmodel' | 'bigmodel'
+    Cluster?: string
+    AccessToken?: string
+    ApiResourceId?: string
+    StreamMode?: number
+  }
+  VADConfig?: {
+    SilenceTime?: number
+    PrefixTime?: number
+    SuffixTime?: number
+    AIVAD?: boolean
+  }
+  VolumeGain?: number
+  TurnDetectionMode?: number
+}
+
+export interface TtsConfig {
+  Provider: string
+  Cluster?: string
+  Mode: 'standard' | 'bigtts' | 'bidirection'
+  VoiceType: string
+  SpeedRatio?: number
+  PitchRatio?: number
+  VolumeRatio?: number
+  SpeechRatio?: number
+  PitchRate?: number
+  SpeechRate?: number
+  Emotion?: string
+  EmotionIntensity?: number
+  IgnoreBracketText?: number[]
+  DisableMarkdownFilter?: boolean
+  EnableLatexTn?: boolean
+}
+
+export interface LlmConfig {
+  Mode: 'ArkV3' | 'CustomLLM'
+  EndpointId?: string
+  SystemMessage?: string
+  VisionEnable?: boolean
+  ModelName?: string
+  Temperature?: number
+  TopP?: number
+  MaxTokens?: number
+  HistoryLength?: number
+  EnableRoundId?: boolean
+  UserPrompts?: Array<Record<string, unknown>>
+  StreamOptions?: Record<string, unknown>
+  ExtraHeaders?: Record<string, unknown>
+}
+
+export interface AvatarSettings {
+  enabled: boolean
+  type: string
+  role: string
+  backgroundUrl: string
+  videoBitrate: number
+}
+
+export interface ApiSettings {
+  region: string
+  version: string
+}
+
+export interface RuntimeConfig {
+  scene: SceneSettings
+  agent: AgentSettings
+  interrupts: InterruptSettings
+  asrConfig: AsrConfig
+  ttsConfig: TtsConfig
+  llmConfig: LlmConfig
+  avatar?: AvatarSettings
+  api: ApiSettings
+}
+
+export const runtimeConfig: RuntimeConfig = {
+  scene: {
+    taskId: 'emq-aigc-task-001',
+    icon: 'https://lf3-rtc-demo.volccdn.com/obj/rtc-aigc-assets/DoubaoAvatar.png',
+    name: 'EMQ 陪伴助手',
+    defaultSceneId: 'emq-mcp-ai-companion',
+  },
+  agent: {
+    userId: 'emq-ai-bot',
+    welcomeMessage: '嗨～我是 EMQ，很高兴见到你！',
+    enableConversationStateCallback: true,
+    ansMode: 2,
+    voiceprintMode: 1,
+  },
+  interrupts: {
+    mode: 2,
+    speechDuration: 400,
+    silenceTime: 600,
+    volumeGain: 0.5,
+    keywords: [
+      '谢谢',
+      '谢谢你',
+      '我知道了',
+      '好的我知道了',
+      '好的',
+      '停',
+      '暂停',
+      '可以了',
+      '别说了',
+      'Stop',
+      'Thank you',
+      'Got it',
+      "I'm good",
+      'Okay',
+      'Enough',
+      'Pause',
+    ],
+  },
+  asrConfig: {
+    Provider: 'volcano',
+    ProviderParams: {
+      Mode: 'smallmodel',
+      Cluster: 'volcengine_streaming_common',
+    },
+    VADConfig: {
+      SilenceTime: 600,
+    },
+    VolumeGain: 0.5,
+    TurnDetectionMode: 0,
+  },
+  ttsConfig: {
+    Provider: 'volcano',
+    Cluster: 'volcano_tts',
+    Mode: 'standard',
+    VoiceType: 'BV033_streaming',
+    SpeedRatio: 1.2,
+    PitchRatio: 1.1,
+    VolumeRatio: 1,
+    SpeechRatio: 0.8,
+    PitchRate: 0,
+    SpeechRate: 0.4,
+    Emotion: 'happy',
+    EmotionIntensity: 0.8,
+    IgnoreBracketText: [],
+    DisableMarkdownFilter: false,
+    EnableLatexTn: false,
+  },
+  llmConfig: {
+    Mode: 'CustomLLM',
+    EndpointId: '',
+    SystemMessage: '',
+    VisionEnable: false,
+    ModelName: 'qwen-flash',
+    Temperature: 0.5,
+    TopP: 0.9,
+    MaxTokens: 256,
+    HistoryLength: 15,
+    EnableRoundId: true,
+    UserPrompts: [
+      { Role: 'assistant', Content: '嗨～我是 EMQ，很高兴见到你！' },
+      { Role: 'user', Content: '你好' },
+    ],
+    StreamOptions: { include_usage: true },
+    ExtraHeaders: undefined,
+  },
+  // avatar: {
+  //   enabled: false,
+  //   type: '3min',
+  //   role: '250623-zhibo-linyunzhi',
+  //   backgroundUrl: '',
+  //   videoBitrate: 2000,
+  // },
+  api: {
+    region: 'cn-north-1',
+    version: '2024-12-01',
+  },
+}

--- a/volc-server/src/env.ts
+++ b/volc-server/src/env.ts
@@ -1,240 +1,38 @@
-import { z } from 'zod'
-
-/**
- * Default interrupt keywords used when VOLC_INTERRUPT_KEYWORDS is not provided.
- */
-const DEFAULT_INTERRUPT_KEYWORDS = [
-  '谢谢',
-  '谢谢你',
-  '我知道了',
-  '好的我知道了',
-  '好的',
-  '停',
-  '暂停',
-  '可以了',
-  '别说了',
-  'Stop',
-  'Thank you',
-  'Got it',
-  "I'm good",
-  'Okay',
-  'Enough',
-  'Pause',
-]
-
-/**
- * Convert a string env value into a number, returning a fallback when invalid.
- */
-const parseNumber = (value: string | undefined, fallback: number): number => {
-  if (!value) return fallback
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : fallback
-}
-
-/**
- * Variant of parseNumber that preserves `undefined` when parsing fails.
- */
-const parseOptionalNumber = (value: string | undefined): number | undefined => {
-  if (value === undefined) {
-    return undefined
-  }
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : undefined
-}
-
-/**
- * Accept JSON arrays or comma-separated lists for interrupt keywords.
- */
-const parseKeywords = (value: string | undefined): string[] => {
-  if (!value) return [...DEFAULT_INTERRUPT_KEYWORDS]
-  try {
-    const parsed = JSON.parse(value)
-    if (Array.isArray(parsed) && parsed.every((item) => typeof item === 'string')) {
-      return parsed.length ? parsed : [...DEFAULT_INTERRUPT_KEYWORDS]
-    }
-  } catch (error) {
-    // Ignore JSON parsing errors and fall back to comma-separated values
-  }
-  const keywords = value
-    .split(',')
-    .map((keyword) => keyword.trim())
-    .filter((keyword) => keyword.length > 0)
-  return keywords.length ? keywords : [...DEFAULT_INTERRUPT_KEYWORDS]
-}
-
-/**
- * Convert JSON/comma-separated numbers into an array of numeric values.
- */
-const parseNumberArray = (value: string | undefined): number[] => {
-  if (!value) return []
-  try {
-    const parsed = JSON.parse(value)
-    if (Array.isArray(parsed)) {
-      return parsed
-        .map((item) => Number(item))
-        .filter((item) => Number.isFinite(item))
-    }
-  } catch (error) {
-    // Ignore JSON parsing errors and fall back to comma-separated values
+const requireEnv = (key: string) => {
+  const value = Bun.env[key]
+  if (!value) {
+    throw new Error(`${key} is required`)
   }
   return value
-    .split(',')
-    .map((item) => Number(item.trim()))
-    .filter((item) => Number.isFinite(item))
 }
 
-/**
- * Normalize boolean-ish strings (1/0, true/false, yes/no, on/off).
- */
-const parseBoolean = (value: string | undefined, fallback = false): boolean => {
-  if (value === undefined) return fallback
-  const normalized = value.trim().toLowerCase()
-  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
-    return true
-  }
-  if (['0', 'false', 'no', 'off'].includes(normalized)) {
-    return false
-  }
-  return fallback
+const optionalEnv = (key: string) => {
+  const value = Bun.env[key]
+  return value && value.length ? value : undefined
 }
 
-/**
- * Canonical schema describing every env var the Volc proxy consumes.
- */
-const envSchema = z.object({
-  // VolcEngine credentials
-  VOLC_ACCESS_KEY_ID: z.string().min(1, 'VOLC_ACCESS_KEY_ID is required'),
-  VOLC_SECRET_KEY: z.string().min(1, 'VOLC_SECRET_KEY is required'),
+export interface RuntimeEnv {
+  VOLC_ACCESS_KEY_ID: string
+  VOLC_SECRET_KEY: string
+  VOLC_RTC_APP_ID: string
+  VOLC_RTC_APP_KEY: string
+  VOLC_ASR_APP_ID?: string
+  VOLC_TTS_APP_ID?: string
+  VOLC_TTS_APP_TOKEN?: string
+  VOLC_TTS_RESOURCE_ID?: string
+  VOLC_LLM_URL?: string
+  VOLC_LLM_API_KEY?: string
+}
 
-  // RTC configuration
-  VOLC_RTC_APP_ID: z.string().min(1, 'VOLC_RTC_APP_ID is required'),
-  VOLC_RTC_APP_KEY: z.string().min(1, 'VOLC_RTC_APP_KEY is required'),
-
-  // ASR/TTS configuration
-  VOLC_ASR_APP_ID: z.string().optional(),
-  VOLC_TTS_APP_ID: z.string().optional(),
-  VOLC_ASR_CLUSTER: z.string().default('volcengine_streaming_common'),
-  VOLC_TTS_CLUSTER: z.string().default('volcano_tts'),
-
-  // Voice configuration
-  VOLC_TTS_VOICE_TYPE: z.string().default('BV001_streaming'),
-  VOLC_TTS_PROVIDER: z.string().default('volcano'),
-  VOLC_TTS_MODE: z.enum(['standard', 'bigtts', 'bidirection']).default('standard'),
-  VOLC_TTS_SPEED_RATIO: z.number().default(1),
-  VOLC_TTS_PITCH_RATIO: z.number().default(1),
-  VOLC_TTS_VOLUME_RATIO: z.number().default(1),
-  VOLC_TTS_SPEECH_RATIO: z.number().default(1),
-  VOLC_TTS_PITCH_RATE: z.number().default(0),
-  VOLC_TTS_SPEECH_RATE: z.number().default(0),
-  VOLC_TTS_APP_TOKEN: z.string().optional(),
-  VOLC_TTS_RESOURCE_ID: z.string().optional(),
-  VOLC_TTS_IGNORE_BRACKET_TEXT: z.array(z.number()).default([]),
-  VOLC_TTS_EMOTION: z.string().optional(),
-  VOLC_TTS_EMOTION_INTENSITY: z.number().default(0),
-  VOLC_TTS_DISABLE_MARKDOWN_FILTER: z.boolean().default(false),
-  VOLC_TTS_ENABLE_LATEX_TN: z.boolean().default(false),
-
-  // LLM configuration
-  VOLC_LLM_MODE: z.string().default('ArkV3'),
-  VOLC_LLM_ENDPOINT_ID: z.string().optional(),
-  VOLC_LLM_SYSTEM_MESSAGE: z.string().default(''),
-  VOLC_LLM_VISION_ENABLE: z.boolean().default(false),
-  VOLC_LLM_URL: z.string().optional(),
-  VOLC_LLM_API_KEY: z.string().optional(),
-  VOLC_LLM_EXTRA_HEADERS: z.string().optional(),
-  VOLC_LLM_MODEL_NAME: z.string().optional(),
-  VOLC_LLM_TEMPERATURE: z.number().optional(),
-  VOLC_LLM_TOP_P: z.number().optional(),
-  VOLC_LLM_MAX_TOKENS: z.number().optional(),
-  VOLC_LLM_HISTORY_LENGTH: z.number().optional(),
-  VOLC_LLM_ENABLE_ROUND_ID: z.boolean().default(false),
-  VOLC_LLM_USER_PROMPTS: z.string().optional(),
-  VOLC_LLM_STREAM_OPTIONS: z.string().optional(),
-
-  // Agent configuration
-  VOLC_AGENT_USER_ID: z.string().default('emq-ai-bot'),
-  VOLC_AGENT_WELCOME_MESSAGE: z.string().default('你好，我是 EMQ，有什么需要帮忙的吗？'),
-  VOLC_AGENT_ENABLE_CONVERSATION_CALLBACK: z.boolean().default(true),
-  VOLC_AGENT_ANS_MODE: z.number().default(2),
-  VOLC_AGENT_VOICEPRINT_MODE: z.number().default(1),
-
-  // Task configuration
-  VOLC_TASK_ID: z.string().default('emq-aigc-task-001'),
-
-  // Scene configuration
-  VOLC_SCENE_ICON: z.string().default('https://lf3-rtc-demo.volccdn.com/obj/rtc-aigc-assets/DoubaoAvatar.png'),
-  VOLC_SCENE_NAME: z.string().default('EMQ 陪伴助手'),
-  VOLC_SCENE_DEFAULT: z.string().min(1).default('emq-mcp-ai-companion'),
-
-  // Avatar configuration
-  VOLC_AVATAR_ENABLED: z.boolean().default(false),
-  VOLC_AVATAR_TYPE: z.string().default('3min'),
-  VOLC_AVATAR_ROLE: z.string().default('250623-zhibo-linyunzhi'),
-  VOLC_AVATAR_BACKGROUND_URL: z.string().default(''),
-  VOLC_AVATAR_VIDEO_BITRATE: z.number().default(2000),
-
-  // API configuration
-  VOLC_API_REGION: z.string().min(1).default('cn-north-1'),
-  VOLC_API_VERSION: z.string().min(1).default('2024-12-01'),
-  VOLC_INTERRUPT_MODE: z.number().default(0),
-  VOLC_INTERRUPT_SPEECH_DURATION: z.number().min(0).max(3000).default(600),
-  VOLC_INTERRUPT_SILENCE_TIME: z.number().min(0).max(5000).default(1000),
-  VOLC_INTERRUPT_VOLUME_GAIN: z.number().min(0).max(5).default(0.6),
-  VOLC_INTERRUPT_KEYWORDS: z.array(z.string()).default(DEFAULT_INTERRUPT_KEYWORDS),
+export const getEnv = (): RuntimeEnv => ({
+  VOLC_ACCESS_KEY_ID: requireEnv('VOLC_ACCESS_KEY_ID'),
+  VOLC_SECRET_KEY: requireEnv('VOLC_SECRET_KEY'),
+  VOLC_RTC_APP_ID: requireEnv('VOLC_RTC_APP_ID'),
+  VOLC_RTC_APP_KEY: requireEnv('VOLC_RTC_APP_KEY'),
+  VOLC_ASR_APP_ID: optionalEnv('VOLC_ASR_APP_ID'),
+  VOLC_TTS_APP_ID: optionalEnv('VOLC_TTS_APP_ID'),
+  VOLC_TTS_APP_TOKEN: optionalEnv('VOLC_TTS_APP_TOKEN'),
+  VOLC_TTS_RESOURCE_ID: optionalEnv('VOLC_TTS_RESOURCE_ID'),
+  VOLC_LLM_URL: optionalEnv('VOLC_LLM_URL'),
+  VOLC_LLM_API_KEY: optionalEnv('VOLC_LLM_API_KEY'),
 })
-
-export type RuntimeEnv = z.infer<typeof envSchema>
-
-/**
- * Read and validate Bun.env, converting strings into richer types as necessary.
- */
-export const getEnv = (): RuntimeEnv => {
-  // Convert string environment variables to appropriate types
-  const processedEnv = {
-    ...Bun.env,
-    VOLC_TTS_PROVIDER: Bun.env.VOLC_TTS_PROVIDER || undefined,
-    VOLC_TTS_MODE: Bun.env.VOLC_TTS_MODE ? Bun.env.VOLC_TTS_MODE.toLowerCase() : undefined,
-    VOLC_TTS_APP_TOKEN: Bun.env.VOLC_TTS_APP_TOKEN || undefined,
-    VOLC_TTS_RESOURCE_ID: Bun.env.VOLC_TTS_RESOURCE_ID || undefined,
-    VOLC_TTS_SPEED_RATIO: parseNumber(Bun.env.VOLC_TTS_SPEED_RATIO, 1),
-    VOLC_TTS_PITCH_RATIO: parseNumber(Bun.env.VOLC_TTS_PITCH_RATIO, 1),
-    VOLC_TTS_VOLUME_RATIO: parseNumber(Bun.env.VOLC_TTS_VOLUME_RATIO, 1),
-    VOLC_TTS_SPEECH_RATIO: parseNumber(Bun.env.VOLC_TTS_SPEECH_RATIO, 1),
-    VOLC_TTS_PITCH_RATE: parseNumber(Bun.env.VOLC_TTS_PITCH_RATE, 0),
-    VOLC_TTS_SPEECH_RATE: parseNumber(Bun.env.VOLC_TTS_SPEECH_RATE, 0),
-    VOLC_TTS_IGNORE_BRACKET_TEXT: parseNumberArray(Bun.env.VOLC_TTS_IGNORE_BRACKET_TEXT),
-    VOLC_TTS_EMOTION: Bun.env.VOLC_TTS_EMOTION || undefined,
-    VOLC_TTS_EMOTION_INTENSITY: parseNumber(Bun.env.VOLC_TTS_EMOTION_INTENSITY, 0),
-    VOLC_LLM_VISION_ENABLE: Bun.env.VOLC_LLM_VISION_ENABLE === 'true',
-    VOLC_LLM_URL: Bun.env.VOLC_LLM_URL || undefined,
-    VOLC_LLM_API_KEY: Bun.env.VOLC_LLM_API_KEY || undefined,
-    VOLC_LLM_EXTRA_HEADERS: Bun.env.VOLC_LLM_EXTRA_HEADERS || undefined,
-    VOLC_LLM_MODEL_NAME: Bun.env.VOLC_LLM_MODEL_NAME || undefined,
-    VOLC_LLM_TEMPERATURE: parseOptionalNumber(Bun.env.VOLC_LLM_TEMPERATURE),
-    VOLC_LLM_TOP_P: parseOptionalNumber(Bun.env.VOLC_LLM_TOP_P),
-    VOLC_LLM_MAX_TOKENS: parseOptionalNumber(Bun.env.VOLC_LLM_MAX_TOKENS),
-    VOLC_LLM_HISTORY_LENGTH: parseOptionalNumber(Bun.env.VOLC_LLM_HISTORY_LENGTH),
-    VOLC_LLM_ENABLE_ROUND_ID: parseBoolean(Bun.env.VOLC_LLM_ENABLE_ROUND_ID, false),
-    VOLC_LLM_USER_PROMPTS: Bun.env.VOLC_LLM_USER_PROMPTS || undefined,
-    VOLC_LLM_STREAM_OPTIONS: Bun.env.VOLC_LLM_STREAM_OPTIONS || undefined,
-    VOLC_AGENT_ENABLE_CONVERSATION_CALLBACK: Bun.env.VOLC_AGENT_ENABLE_CONVERSATION_CALLBACK !== 'false',
-    VOLC_AGENT_ANS_MODE: parseNumber(Bun.env.VOLC_AGENT_ANS_MODE, 2),
-    VOLC_AGENT_VOICEPRINT_MODE: parseNumber(Bun.env.VOLC_AGENT_VOICEPRINT_MODE, 1),
-    VOLC_AVATAR_ENABLED: Bun.env.VOLC_AVATAR_ENABLED === 'true',
-    VOLC_AVATAR_VIDEO_BITRATE: parseNumber(Bun.env.VOLC_AVATAR_VIDEO_BITRATE, 2000),
-    VOLC_INTERRUPT_MODE: parseNumber(Bun.env.VOLC_INTERRUPT_MODE, 0),
-    VOLC_INTERRUPT_SPEECH_DURATION: parseNumber(Bun.env.VOLC_INTERRUPT_SPEECH_DURATION, 600),
-    VOLC_INTERRUPT_SILENCE_TIME: parseNumber(Bun.env.VOLC_INTERRUPT_SILENCE_TIME, 1000),
-    VOLC_INTERRUPT_VOLUME_GAIN: parseNumber(Bun.env.VOLC_INTERRUPT_VOLUME_GAIN, 0.6),
-    VOLC_INTERRUPT_KEYWORDS: parseKeywords(Bun.env.VOLC_INTERRUPT_KEYWORDS),
-    VOLC_TTS_DISABLE_MARKDOWN_FILTER: parseBoolean(Bun.env.VOLC_TTS_DISABLE_MARKDOWN_FILTER),
-    VOLC_TTS_ENABLE_LATEX_TN: parseBoolean(Bun.env.VOLC_TTS_ENABLE_LATEX_TN),
-  }
-
-  const result = envSchema.safeParse(processedEnv)
-  if (!result.success) {
-    const messages = result.error.issues.map((issue) => issue.message).filter(Boolean)
-    throw new Error(messages.length ? messages.join('; ') : 'Environment variables validation failed')
-  }
-  return result.data
-}

--- a/volc-server/src/handlers.ts
+++ b/volc-server/src/handlers.ts
@@ -3,6 +3,7 @@ import { loadScenes, summarizeScenes, getScene, prepareSceneForRequest } from '.
 import type { RuntimeEnv } from './env'
 import type { SceneFile, SceneSummary } from './types'
 import { serverLogger } from './logger'
+import { runtimeConfig } from './config'
 
 type JsonValue = Record<string, unknown> | Array<unknown> | string | number | boolean | null
 
@@ -161,7 +162,7 @@ const callVolcApi = async (scene: SceneFile, env: RuntimeEnv, action: string, ve
   }
 
   const openApiRequestData = {
-    region: env.VOLC_API_REGION,
+    region: runtimeConfig.api.region,
     method: 'POST',
     params: {
       Action: action,
@@ -198,10 +199,13 @@ const makeSceneSummaries = (scenes: Map<string, SceneFile>): SceneSummary[] => s
  */
 export const createRequestHandler = (env: RuntimeEnv) => {
   const scenes = loadScenes(env)
-  serverLogger.info('Request handler initialized', { sceneCount: scenes.size, defaultScene: env.VOLC_SCENE_DEFAULT })
+  serverLogger.info('Request handler initialized', {
+    sceneCount: scenes.size,
+    defaultScene: runtimeConfig.scene.defaultSceneId,
+  })
 
   const resolveScene = (sceneId?: string): SceneFile => {
-    const id = sceneId && sceneId.trim().length ? sceneId : env.VOLC_SCENE_DEFAULT
+    const id = sceneId && sceneId.trim().length ? sceneId : runtimeConfig.scene.defaultSceneId
     serverLogger.debug('Resolving scene', { requestedSceneId: sceneId, resolvedId: id })
     const scene = getScene(scenes, id)
     if (!scene) {
@@ -233,7 +237,7 @@ export const createRequestHandler = (env: RuntimeEnv) => {
   const handleProxy = async (req: Request) => {
     const url = new URL(req.url)
     const action = url.searchParams.get('Action')
-    const version = url.searchParams.get('Version') ?? env.VOLC_API_VERSION
+    const version = url.searchParams.get('Version') ?? runtimeConfig.api.version
 
     serverLogger.info('Handling proxy request', { action, version })
 

--- a/volc-server/src/scenes/loader.ts
+++ b/volc-server/src/scenes/loader.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { AccessToken } from '../lib/token'
+import { runtimeConfig } from '../config'
 import type { RuntimeEnv } from '../env'
 import type { SceneFile, SceneSummary, VoiceChatConfig } from '../types'
 
@@ -13,36 +14,9 @@ const asOptionalString = (value: unknown): string | undefined => {
   return trimmed.length ? trimmed : undefined
 }
 
-const toJsonObject = (value?: string): Record<string, unknown> | undefined => {
-  if (!value) {
-    return undefined
-  }
-  try {
-    const parsed = JSON.parse(value)
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>
-    }
-  } catch (error) {
-    // Ignore JSON parsing errors and fall back to undefined
-  }
-  return undefined
-}
-
-const toJsonArray = (value?: string): unknown[] | undefined => {
-  if (!value) {
-    return undefined
-  }
-  try {
-    const parsed = JSON.parse(value)
-    return Array.isArray(parsed) ? parsed : undefined
-  } catch (error) {
-    // Ignore JSON parsing errors and fall back to undefined
-  }
-  return undefined
-}
-
 /**
- * Create the in-memory scene representation directly from environment variables.
+ * Create the in-memory scene representation by combining secrets from .env
+ * with the shareable defaults defined in runtimeConfig.
  */
 const createSceneFromEnv = (env: RuntimeEnv): SceneFile => {
   const roomId = randomUUID()
@@ -50,37 +24,52 @@ const createSceneFromEnv = (env: RuntimeEnv): SceneFile => {
 
   const agentConfig: VoiceChatConfig['AgentConfig'] = {
     TargetUserId: [userId],
-    WelcomeMessage: env.VOLC_AGENT_WELCOME_MESSAGE,
-    UserId: env.VOLC_AGENT_USER_ID,
-    EnableConversationStateCallback: env.VOLC_AGENT_ENABLE_CONVERSATION_CALLBACK,
-    AnsMode: env.VOLC_AGENT_ANS_MODE,
+    WelcomeMessage: runtimeConfig.agent.welcomeMessage,
+    UserId: runtimeConfig.agent.userId,
+    EnableConversationStateCallback: runtimeConfig.agent.enableConversationStateCallback,
+    AnsMode: runtimeConfig.agent.ansMode,
   }
 
-  if (env.VOLC_AGENT_VOICEPRINT_MODE > 0) {
+  if (runtimeConfig.agent.voiceprintMode > 0) {
     agentConfig.VoicePrint = {
-      Mode: env.VOLC_AGENT_VOICEPRINT_MODE,
+      Mode: runtimeConfig.agent.voiceprintMode,
     }
   }
 
   const interruptConfig: Record<string, unknown> = {}
-  if (env.VOLC_INTERRUPT_SPEECH_DURATION > 0) {
-    interruptConfig.InterruptSpeechDuration = env.VOLC_INTERRUPT_SPEECH_DURATION
+  if (runtimeConfig.interrupts.speechDuration > 0) {
+    interruptConfig.InterruptSpeechDuration = runtimeConfig.interrupts.speechDuration
   }
-  if (env.VOLC_INTERRUPT_KEYWORDS.length > 0) {
-    interruptConfig.InterruptKeywords = env.VOLC_INTERRUPT_KEYWORDS
+  if (runtimeConfig.interrupts.keywords.length > 0) {
+    interruptConfig.InterruptKeywords = runtimeConfig.interrupts.keywords
+  }
+
+  const asrProviderParams: Record<string, unknown> = {
+    ...runtimeConfig.asrConfig.ProviderParams,
+    AppId: env.VOLC_ASR_APP_ID || '',
   }
 
   const asrConfig: Record<string, unknown> = {
-    Provider: 'volcano',
-    ProviderParams: {
-      Mode: 'smallmodel',
-      AppId: env.VOLC_ASR_APP_ID || '',
-      Cluster: env.VOLC_ASR_CLUSTER,
-    },
-    VADConfig: {
-      SilenceTime: env.VOLC_INTERRUPT_SILENCE_TIME,
-    },
-    VolumeGain: env.VOLC_INTERRUPT_VOLUME_GAIN,
+    Provider: runtimeConfig.asrConfig.Provider,
+    ProviderParams: asrProviderParams,
+  }
+
+  const vadConfig: Record<string, unknown> = { ...(runtimeConfig.asrConfig.VADConfig ?? {}) }
+  if (vadConfig.SilenceTime === undefined) {
+    vadConfig.SilenceTime = runtimeConfig.interrupts.silenceTime
+  }
+  if (Object.keys(vadConfig).length > 0) {
+    asrConfig.VADConfig = vadConfig
+  }
+
+  if (runtimeConfig.asrConfig.VolumeGain !== undefined) {
+    asrConfig.VolumeGain = runtimeConfig.asrConfig.VolumeGain
+  } else {
+    asrConfig.VolumeGain = runtimeConfig.interrupts.volumeGain
+  }
+
+  if (runtimeConfig.asrConfig.TurnDetectionMode !== undefined) {
+    asrConfig.TurnDetectionMode = runtimeConfig.asrConfig.TurnDetectionMode
   }
 
   if (Object.keys(interruptConfig).length > 0) {
@@ -88,31 +77,31 @@ const createSceneFromEnv = (env: RuntimeEnv): SceneFile => {
   }
 
   const ttsAudioConfig: Record<string, unknown> = {
-    voice_type: env.VOLC_TTS_VOICE_TYPE,
+    voice_type: runtimeConfig.ttsConfig.VoiceType,
   }
 
-  switch (env.VOLC_TTS_MODE) {
+  switch (runtimeConfig.ttsConfig.Mode) {
     case 'bigtts':
-      ttsAudioConfig.speech_ratio = env.VOLC_TTS_SPEECH_RATIO
-      ttsAudioConfig.pitch_rate = env.VOLC_TTS_PITCH_RATE
-      ttsAudioConfig.volume_ratio = env.VOLC_TTS_VOLUME_RATIO
+      ttsAudioConfig.speech_ratio = runtimeConfig.ttsConfig.SpeechRatio
+      ttsAudioConfig.pitch_rate = runtimeConfig.ttsConfig.PitchRate
+      ttsAudioConfig.volume_ratio = runtimeConfig.ttsConfig.VolumeRatio
       break
     case 'bidirection':
-      ttsAudioConfig.speech_rate = env.VOLC_TTS_SPEECH_RATE
-      ttsAudioConfig.volume_ratio = env.VOLC_TTS_VOLUME_RATIO
-      ttsAudioConfig.pitch_ratio = env.VOLC_TTS_PITCH_RATIO
+      ttsAudioConfig.speech_rate = runtimeConfig.ttsConfig.SpeechRate
+      ttsAudioConfig.volume_ratio = runtimeConfig.ttsConfig.VolumeRatio
+      ttsAudioConfig.pitch_ratio = runtimeConfig.ttsConfig.PitchRatio
       break
     default:
-      ttsAudioConfig.speed_ratio = env.VOLC_TTS_SPEED_RATIO
-      ttsAudioConfig.pitch_ratio = env.VOLC_TTS_PITCH_RATIO
-      ttsAudioConfig.volume_ratio = env.VOLC_TTS_VOLUME_RATIO
+      ttsAudioConfig.speed_ratio = runtimeConfig.ttsConfig.SpeedRatio
+      ttsAudioConfig.pitch_ratio = runtimeConfig.ttsConfig.PitchRatio
+      ttsAudioConfig.volume_ratio = runtimeConfig.ttsConfig.VolumeRatio
       break
   }
 
-  if (env.VOLC_TTS_EMOTION) {
-    ttsAudioConfig.emotion = env.VOLC_TTS_EMOTION
-    if (env.VOLC_TTS_EMOTION_INTENSITY) {
-      ttsAudioConfig.emotion_strength = env.VOLC_TTS_EMOTION_INTENSITY
+  if (runtimeConfig.ttsConfig.Emotion) {
+    ttsAudioConfig.emotion = runtimeConfig.ttsConfig.Emotion
+    if (runtimeConfig.ttsConfig.EmotionIntensity) {
+      ttsAudioConfig.emotion_strength = runtimeConfig.ttsConfig.EmotionIntensity
     }
   }
 
@@ -123,10 +112,10 @@ const createSceneFromEnv = (env: RuntimeEnv): SceneFile => {
     audio: ttsAudioConfig,
   }
 
-  if (env.VOLC_TTS_PROVIDER === 'volcano') {
+  if (runtimeConfig.ttsConfig.Provider === 'volcano' && runtimeConfig.ttsConfig.Cluster) {
     ttsProviderParams.app = {
       ...(ttsProviderParams.app as Record<string, unknown>),
-      cluster: env.VOLC_TTS_CLUSTER,
+      cluster: runtimeConfig.ttsConfig.Cluster,
     }
   }
 
@@ -138,12 +127,12 @@ const createSceneFromEnv = (env: RuntimeEnv): SceneFile => {
     ttsProviderParams.ResourceId = env.VOLC_TTS_RESOURCE_ID
   }
 
-  if (env.VOLC_TTS_MODE === 'bidirection') {
+  if (runtimeConfig.ttsConfig.Mode === 'bidirection') {
     const additions: Record<string, unknown> = {}
-    if (env.VOLC_TTS_DISABLE_MARKDOWN_FILTER) {
+    if (runtimeConfig.ttsConfig.DisableMarkdownFilter) {
       additions.disable_markdown_filter = true
     }
-    if (env.VOLC_TTS_ENABLE_LATEX_TN) {
+    if (runtimeConfig.ttsConfig.EnableLatexTn) {
       additions.enable_latex_tn = true
     }
     if (Object.keys(additions).length > 0) {
@@ -152,39 +141,39 @@ const createSceneFromEnv = (env: RuntimeEnv): SceneFile => {
   }
 
   const ttsConfig: Record<string, unknown> = {
-    Provider: env.VOLC_TTS_PROVIDER,
+    Provider: runtimeConfig.ttsConfig.Provider,
     ProviderParams: ttsProviderParams,
   }
 
-  if (env.VOLC_TTS_IGNORE_BRACKET_TEXT.length > 0) {
-    ttsConfig.IgnoreBracketText = env.VOLC_TTS_IGNORE_BRACKET_TEXT
+  if (runtimeConfig.ttsConfig.IgnoreBracketText && runtimeConfig.ttsConfig.IgnoreBracketText.length > 0) {
+    ttsConfig.IgnoreBracketText = runtimeConfig.ttsConfig.IgnoreBracketText
   }
 
   const llmConfig: Record<string, unknown> = {
-    Mode: env.VOLC_LLM_MODE,
+    Mode: runtimeConfig.llmConfig.Mode,
     VisionConfig: {
-      Enable: env.VOLC_LLM_VISION_ENABLE,
+      Enable: Boolean(runtimeConfig.llmConfig.VisionEnable),
     },
   }
 
-  const systemMessage = asOptionalString(env.VOLC_LLM_SYSTEM_MESSAGE)
+  const systemMessage = asOptionalString(runtimeConfig.llmConfig.SystemMessage)
   if (systemMessage) {
     llmConfig.SystemMessages = [systemMessage]
   }
 
-  if (env.VOLC_LLM_ENDPOINT_ID) {
-    llmConfig.EndPointId = env.VOLC_LLM_ENDPOINT_ID
+  if (runtimeConfig.llmConfig.EndpointId) {
+    llmConfig.EndPointId = runtimeConfig.llmConfig.EndpointId
   }
 
-  if (env.VOLC_LLM_MODEL_NAME) {
-    llmConfig.ModelName = env.VOLC_LLM_MODEL_NAME
+  if (runtimeConfig.llmConfig.ModelName) {
+    llmConfig.ModelName = runtimeConfig.llmConfig.ModelName
   }
 
-  if (env.VOLC_LLM_HISTORY_LENGTH !== undefined) {
-    llmConfig.HistoryLength = env.VOLC_LLM_HISTORY_LENGTH
+  if (runtimeConfig.llmConfig.HistoryLength !== undefined) {
+    llmConfig.HistoryLength = runtimeConfig.llmConfig.HistoryLength
   }
 
-  if (env.VOLC_LLM_ENABLE_ROUND_ID) {
+  if (runtimeConfig.llmConfig.EnableRoundId) {
     llmConfig.EnableRoundId = true
   }
 
@@ -194,28 +183,25 @@ const createSceneFromEnv = (env: RuntimeEnv): SceneFile => {
     }
   }
 
-  setNumericConfig('Temperature', env.VOLC_LLM_TEMPERATURE)
-  setNumericConfig('TopP', env.VOLC_LLM_TOP_P)
-  setNumericConfig('MaxTokens', env.VOLC_LLM_MAX_TOKENS)
+  setNumericConfig('Temperature', runtimeConfig.llmConfig.Temperature)
+  setNumericConfig('TopP', runtimeConfig.llmConfig.TopP)
+  setNumericConfig('MaxTokens', runtimeConfig.llmConfig.MaxTokens)
 
-  const extraHeaders = toJsonObject(env.VOLC_LLM_EXTRA_HEADERS)
-  if (extraHeaders) {
-    llmConfig.ExtraHeader = extraHeaders
+  if (runtimeConfig.llmConfig.ExtraHeaders) {
+    llmConfig.ExtraHeader = runtimeConfig.llmConfig.ExtraHeaders
   }
 
-  const userPrompts = toJsonArray(env.VOLC_LLM_USER_PROMPTS)
-  if (userPrompts) {
-    llmConfig.UserPrompts = userPrompts
+  if (runtimeConfig.llmConfig.UserPrompts && runtimeConfig.llmConfig.UserPrompts.length > 0) {
+    llmConfig.UserPrompts = runtimeConfig.llmConfig.UserPrompts
   }
 
-  const streamOptions = toJsonObject(env.VOLC_LLM_STREAM_OPTIONS)
-  if (streamOptions) {
-    llmConfig.StreamOptions = streamOptions
+  if (runtimeConfig.llmConfig.StreamOptions) {
+    llmConfig.StreamOptions = runtimeConfig.llmConfig.StreamOptions
   }
 
-  if (env.VOLC_LLM_MODE === 'CustomLLM') {
+  if (runtimeConfig.llmConfig.Mode === 'CustomLLM') {
     if (!env.VOLC_LLM_URL) {
-      throw new Error('VOLC_LLM_URL is required when VOLC_LLM_MODE=CustomLLM')
+      throw new Error('VOLC_LLM_URL is required when llmConfig.Mode=CustomLLM')
     }
     llmConfig.Url = env.VOLC_LLM_URL
 
@@ -224,17 +210,17 @@ const createSceneFromEnv = (env: RuntimeEnv): SceneFile => {
     }
   }
 
-  const scene: SceneFile = {
+  const sceneFile: SceneFile = {
     SceneConfig: {
-      icon: env.VOLC_SCENE_ICON,
-      name: env.VOLC_SCENE_NAME,
-      id: 'emq-mcp-ai-companion',
-      botName: env.VOLC_AGENT_USER_ID,
-      isInterruptMode: env.VOLC_INTERRUPT_MODE === 0,
-      isVision: env.VOLC_LLM_VISION_ENABLE,
+      icon: runtimeConfig.scene.icon,
+      name: runtimeConfig.scene.name,
+      id: runtimeConfig.scene.defaultSceneId,
+      botName: runtimeConfig.agent.userId,
+      isInterruptMode: runtimeConfig.interrupts.mode === 0,
+      isVision: Boolean(runtimeConfig.llmConfig.VisionEnable),
       isScreenMode: false,
-      isAvatarScene: env.VOLC_AVATAR_ENABLED,
-      avatarBgUrl: env.VOLC_AVATAR_BACKGROUND_URL,
+      isAvatarScene: runtimeConfig.avatar?.enabled,
+      avatarBgUrl: runtimeConfig.avatar?.backgroundUrl,
     },
     AccountConfig: {
       accessKeyId: env.VOLC_ACCESS_KEY_ID,
@@ -245,32 +231,32 @@ const createSceneFromEnv = (env: RuntimeEnv): SceneFile => {
       AppKey: env.VOLC_RTC_APP_KEY,
       RoomId: roomId,
       UserId: userId,
-      Token: '', // Will be generated by buildToken
+      Token: '',
     },
     VoiceChat: {
       AppId: env.VOLC_RTC_APP_ID,
       RoomId: roomId,
-      TaskId: env.VOLC_TASK_ID,
+      TaskId: runtimeConfig.scene.taskId,
       AgentConfig: agentConfig,
       Config: {
         ASRConfig: asrConfig,
         TTSConfig: ttsConfig,
         LLMConfig: llmConfig,
         AvatarConfig: {
-          Enabled: env.VOLC_AVATAR_ENABLED,
-          AvatarType: env.VOLC_AVATAR_TYPE,
-          AvatarRole: env.VOLC_AVATAR_ROLE,
-          BackgroundUrl: env.VOLC_AVATAR_BACKGROUND_URL,
-          VideoBitrate: env.VOLC_AVATAR_VIDEO_BITRATE,
+          Enabled: runtimeConfig.avatar?.enabled,
+          AvatarType: runtimeConfig.avatar?.type,
+          AvatarRole: runtimeConfig.avatar?.role,
+          BackgroundUrl: runtimeConfig.avatar?.backgroundUrl,
+          VideoBitrate: runtimeConfig.avatar?.videoBitrate,
           AvatarAppID: '',
           AvatarToken: '',
         },
-        InterruptMode: env.VOLC_INTERRUPT_MODE,
+        InterruptMode: runtimeConfig.interrupts.mode,
       },
     },
   }
 
-  return scene
+  return sceneFile
 }
 
 /**
@@ -331,7 +317,7 @@ export const loadScenes = (env: RuntimeEnv) => {
   // Generate RTC token
   buildToken(scene.RTCConfig, env.VOLC_RTC_APP_KEY)
 
-  scenes.set('emq-mcp-ai-companion', scene)
+  scenes.set(runtimeConfig.scene.defaultSceneId, scene)
 
   return scenes
 }


### PR DESCRIPTION
- Move non-sensitive config from .env to src/config.ts for better maintainability
- Simplify env.ts to only validate required credentials
- Update handlers and scene loader to merge env secrets with runtimeConfig
- Update documentation to reflect new configuration approach