### PR TITLE
refactor: centralize MCP server name constant and improve logging

### DIFF
--- a/app/mcp_client_init.py
+++ b/app/mcp_client_init.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import traceback
 from contextlib import AsyncExitStack

--- a/web/src/config/mqtt.ts
+++ b/web/src/config/mqtt.ts
@@ -1,4 +1,5 @@
 import { buildMqttWebSocketUrl } from '@/utils/host'
+import { MCP_SERVER_NAME } from '@/constants/mcp'
 
 export interface MqttBrokerConfig {
   brokerUrl: string
@@ -61,7 +62,7 @@ export const defaultMqttConfig: MqttBrokerConfig = {
 // MCP Server configuration
 export const mcpServerConfig: McpMqttConfig = {
   ...defaultMqttConfig,
-  serverName: 'web-ui-hardware-controller',
+  serverName: MCP_SERVER_NAME,
 }
 
 // WebRTC client configuration

--- a/web/src/constants/mcp.ts
+++ b/web/src/constants/mcp.ts
@@ -1,0 +1,12 @@
+/**
+ * MCP Server Constants
+ *
+ * These constants define the core identification values for the MCP server.
+ * They are used across MQTT topic construction, server initialization, and tool routing.
+ */
+
+/**
+ * Base name for the MCP server that exposes hardware control tools
+ * This name is used as a prefix in MQTT topics and server identification
+ */
+export const MCP_SERVER_NAME = 'web-ui-hardware-controller'

--- a/web/src/hooks/useMcpMqttServer.ts
+++ b/web/src/hooks/useMcpMqttServer.ts
@@ -11,6 +11,7 @@ import { mcpServerConfig } from '@/config/mqtt'
 import { mcpLogger } from '@/utils/logger'
 import { McpTools, createToolContext } from '@/tools'
 import { generateRandomId } from '@/utils/id-generator'
+import { MCP_SERVER_NAME } from '@/constants/mcp'
 import type { MqttClient } from 'mqtt'
 
 export interface UseMqttOptions {
@@ -50,8 +51,9 @@ export function useMcpMqttServer(options: UseMqttOptions = {}): UseMqttServerRet
 
   useEffect(() => {
     const randomId = generateRandomId(8)
+    const baseServerName = serverName || MCP_SERVER_NAME
     const serverId = `mcp-ai-web-ui-${randomId}`
-    const fullServerName = `${serverName || 'web-ui-hardware-controller'}/${randomId}`
+    const fullServerName = `${baseServerName}/${randomId}`
 
     const brokerUrl = mqttOptions.brokerUrl || mcpServerConfig.brokerUrl
 
@@ -121,7 +123,7 @@ export function useMcpMqttServer(options: UseMqttOptions = {}): UseMqttServerRet
       })
     })
 
-    mcpLogger.info(`📋 Registered ${tools.length} tools`)
+    mcpLogger.info(`📋 Initialized ${tools.length} tools: ${tools.map((t) => t.name).join(', ')}`)
 
     const serverWithCompat = Object.assign(server, {
       getClientId: () => serverId,

--- a/web/src/lib/mcp-mqtt-server.ts
+++ b/web/src/lib/mcp-mqtt-server.ts
@@ -4,6 +4,7 @@ import { mcpLogger, mqttLogger } from '@/utils/logger'
 import { McpTools, createToolContext } from '@/tools'
 import { defaultMqttConfig } from '@/config/mqtt'
 import { generateRandomId } from '@/utils/id-generator'
+import { MCP_SERVER_NAME } from '@/constants/mcp'
 
 export class McpMqttServer {
   private mqttClient: BaseMqttClient | null = null
@@ -41,7 +42,7 @@ export class McpMqttServer {
     const clientId = `mcp-ai-web-ui-${randomId}`
 
     this.serverId = clientId
-    this.serverName = `${serverName || 'web-ui-hardware-controller'}/${randomId}`
+    this.serverName = `${serverName || MCP_SERVER_NAME}/${randomId}`
     this.callbacks = callbacks || {}
 
     this.connectionOptions = {


### PR DESCRIPTION
- Extract 'web-ui-hardware-controller' to MCP_SERVER_NAME constant
- Update all usages in mqtt config, hooks, and server implementation
- Improve tool initialization logging to list tool names
- Remove unused logging import from mcp_client_init.py